### PR TITLE
Add encoding='utf-8' for open function

### DIFF
--- a/generate_static_files.ipynb
+++ b/generate_static_files.ipynb
@@ -101,7 +101,7 @@
     "    \n",
     "    for file_name in names:\n",
     "        p = nbconvert.export(nbconvert.get_exporter(to_format), file_name)\n",
-    "        with open(os.path.join(target_dir, file_name[:-6] + p[1][\"output_extension\"]), 'w') as f:\n",
+    "        with open(os.path.join(target_dir, file_name[:-6] + p[1][\"output_extension\"]), 'w', encoding='utf-8') as f:\n",
     "            f.write(p[0].encode(\"utf-8\"))\n",
     "        print file_name"
    ]
@@ -283,9 +283,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open('index.md') as f:\n",
+    "with open('index.md', encoding='utf-8') as f:\n",
     "    text = f.read()\n",
-    "    with open(os.path.join(\"static-files\", \"html\", \"README.md\"), \"w\") as g:\n",
+    "    with open(os.path.join(\"static-files\", \"html\", \"README.md\"), \"w\", encoding='utf-8') as g:\n",
     "        g.write(text.replace(\".ipynb\", \".html\"))"
    ]
   }


### PR DESCRIPTION
Windows takes 'gbk' as default, which lead to error ''gbk' codec can't encode character '. Add encoding='utf-8' for open function.